### PR TITLE
Set the default name to the TimeStampedName for new datasets

### DIFF
--- a/pbcore/io/dataset/EntryPoints.py
+++ b/pbcore/io/dataset/EntryPoints.py
@@ -28,7 +28,8 @@ def createXml(args):
     dset = dsTypes[args.dsType](*args.infile, strict=args.strict,
                                 skipCounts=args.skipCounts,
                                 generateIndices=args.generateIndices)
-    dset.name = args.dsName
+    if args.dsName != '':
+        dset.name = args.dsName
     if args.generateIndices:
         # we generated the indices with the last open, lets capture them with
         # this one:

--- a/tests/test_pbdataset.py
+++ b/tests/test_pbdataset.py
@@ -231,6 +231,8 @@ class TestDataSet(unittest.TestCase):
             self.assertEqual(extRes.metaType,
                              "PacBio.AlignmentFile.AlignmentBamFile")
 
+    @unittest.skipIf(not _check_constools(),
+                     "bamtools or pbindex not found, skipping")
     def test_empty_file_counts(self):
         # empty with pbi:
         dset = SubreadSet(upstreamdata.getEmptyBam())
@@ -292,6 +294,13 @@ class TestDataSet(unittest.TestCase):
         dset.updateCounts()
         self.assertEqual(len(dset.resourceReaders()), 1)
 
+        dset = ConsensusAlignmentSet(outpath)
+        self.assertEqual(dset.numRecords, 0)
+        self.assertEqual(dset.totalLength, 0)
+        self.assertEqual(len(list(dset)), 0)
+        dset.updateCounts()
+        self.assertEqual(len(dset.resourceReaders()), 1)
+        dset.induceIndices()
         dset = ConsensusAlignmentSet(outpath)
         self.assertEqual(dset.numRecords, 0)
         self.assertEqual(dset.totalLength, 0)


### PR DESCRIPTION
Also better accommodate emtpy aligned bams by recognizing that the mapping
columns may be missing from a pbi file if generated on an emtpy bam. There may
still be some dark corners for emtpy bam support, but for much beyond this and
the pbi file perhaps should be rectified instead.