### PR TITLE
workaround for empty indexed fasta

### DIFF
--- a/pbcore/io/FastaIO.py
+++ b/pbcore/io/FastaIO.py
@@ -48,7 +48,7 @@ from pbcore.util.decorators import deprecated
 
 import mmap, numpy as np, re
 from collections import namedtuple, OrderedDict, Sequence
-from os.path import abspath, expanduser, isfile
+from os.path import abspath, expanduser, isfile, getsize
 
 
 def splitFastaHeader( name ):
@@ -416,10 +416,14 @@ class IndexedFastaReader(ReaderBase, Sequence):
     def __init__(self, filename):
         self.filename = abspath(expanduser(filename))
         self.file = open(self.filename, "r")
-        self.view = mmap.mmap(self.file.fileno(), 0,
-                              prot=mmap.PROT_READ)
         self.faiFilename = faiFilename(self.filename)
-        self.fai = loadFastaIndex(self.faiFilename, self.view)
+        if getsize(self.filename) > 0:
+            self.view = mmap.mmap(self.file.fileno(), 0,
+                                  prot=mmap.PROT_READ)
+            self.fai = loadFastaIndex(self.faiFilename, self.view)
+        else:
+            self.view = None
+            self.fai = []
         self.contigLookup = self._loadContigLookup()
 
     def _loadContigLookup(self):

--- a/pbcore/io/dataset/DataSetIO.py
+++ b/pbcore/io/dataset/DataSetIO.py
@@ -3505,7 +3505,7 @@ class ContigSet(DataSet):
                 self._skipCounts = True
                 self.metadata.totalLength = 0
                 self.metadata.numRecords = 0
-            if resource:
+            if resource is not None:
                 self._openReaders.append(resource)
         if len(self._openReaders) == 0 and len(self.toExternalFiles()) != 0:
             raise IOError("No files were openable")

--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -191,6 +191,11 @@ class TestDataSet(unittest.TestCase):
         open(fa_file, "w").write("")
         ds = ContigSet(fa_file, strict=False)
         ds.write(ds_file)
+        fai_file = fa_file + ".fai"
+        open(fai_file, "w").write("")
+        ds = ContigSet(fa_file, strict=True)
+        ds.write(ds_file)
+        self.assertEqual(len(ds), 0)
 
     def test_file_factory(self):
         # TODO: add ConsensusReadSet, cmp.h5 alignmentSet


### PR DESCRIPTION
It's not lovely, but this is a valid use case, and I'm pretty sure it won't have side effects.