### PR TITLE
Add support for merged cmph5 AlignmentSets

### DIFF
--- a/tests/test_pbdataset.py
+++ b/tests/test_pbdataset.py
@@ -1528,3 +1528,11 @@ class TestDataSet(unittest.TestCase):
             2876.0, ss.subdatasets[0].metadata.summaryStats.numSequencingZmws)
         self.assertEqual(
             150292.0, ss.subdatasets[1].metadata.summaryStats.numSequencingZmws)
+
+    def test_merged_cmp(self):
+        cmp1 = upstreamdata.getCmpH5s()[0]['cmph5']
+        cmp2 = upstreamdata.getBamAndCmpH5()[1]
+        aln = AlignmentSet(cmp1, cmp2)
+        refnames = aln.refNames
+        self.assertEqual(refnames, ['lambda_NEB3011'])
+        self.assertEqual(aln.refIds[aln.refNames[0]], 1)


### PR DESCRIPTION
This required manipulation of the referenceInfoTable to correct the RowStart
and RowEnd fields, which required reordering the index for cmph5 based
AlignmentSets to make the AlignmentSet as a whole conform to the ordering of a
cmph5. As an added bonus it is now trivial to do the same thing to a bam,
should we choose to in the future. There were some other minor issues uncovered
during the process that have also been resolved, mostly more aggressive cache
clearing and better filter support. Also updated some documentation.