### PR TITLE
Make bam consolidation more space-conservative

### DIFF
--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -240,7 +240,22 @@ class TestDataSet(unittest.TestCase):
         self.assertEqual(len(aln.toExternalFiles()), 2)
         outdir = tempfile.mkdtemp(suffix="dataset-unittest")
         outfn = os.path.join(outdir, 'merged.bam')
-        consolidateBams(aln.toExternalFiles(), outfn, filterDset=aln)
+        consolidateBams(aln.toExternalFiles(), outfn, filterDset=aln,
+                        useTmp=False)
+        self.assertTrue(os.path.exists(outfn))
+        consAln = AlignmentSet(outfn)
+        self.assertEqual(len(consAln.toExternalFiles()), 1)
+        for read1, read2 in zip(sorted(list(aln)), sorted(list(consAln))):
+            self.assertEqual(read1, read2)
+        self.assertEqual(len(aln), len(consAln))
+
+        log.debug("Test methods directly in tmp")
+        aln = AlignmentSet(data.getXml(12))
+        self.assertEqual(len(aln.toExternalFiles()), 2)
+        outdir = tempfile.mkdtemp(suffix="dataset-unittest")
+        outfn = os.path.join(outdir, 'merged.bam')
+        consolidateBams(aln.toExternalFiles(), outfn, filterDset=aln,
+                        useTmp=True)
         self.assertTrue(os.path.exists(outfn))
         consAln = AlignmentSet(outfn)
         self.assertEqual(len(consAln.toExternalFiles()), 1)


### PR DESCRIPTION
- Add an upfront check for space free in final destination.
- Check to make sure there is space for the input and output files plus a
  buffer in tmp before using it (previously only 1x was checked, which isn't
  enough)