### PR TITLE
include file name in IndexedBamReader error message

### DIFF
--- a/pbcore/io/align/BamIO.py
+++ b/pbcore/io/align/BamIO.py
@@ -369,7 +369,8 @@ class IndexedBamReader(_BamReaderBase, IndexedAlignmentReaderMixin):
             if exists(pbiFname):
                 self.pbi = PacBioBamIndex(pbiFname)
             else:
-                raise IOError, "IndexedBamReader requires bam.pbi index file"
+                raise IOError("IndexedBamReader requires bam.pbi index file "+
+                              "to read {f}".format(f=fname))
         else:
             self.pbi = sharedIndex
 


### PR DESCRIPTION
Requested by cdunn - for datasets with a lot of BAM files the old error message was difficult to debug.