### PR TITLE
Don't fail on isEmpty, report True only if all are empty

### DIFF
--- a/pbcore/io/dataset/DataSetIO.py
+++ b/pbcore/io/dataset/DataSetIO.py
@@ -1588,7 +1588,8 @@ class DataSet(object):
 
     @property
     def isEmpty(self):
-        return self._checkIdentical('isEmpty')
+        responses = self._pollResources(lambda x: getattr(x, 'isEmpty'))
+        return all(responses)
 
     @property
     def readType(self):


### PR DESCRIPTION
Previously, member Readers had to have the same response for isEmpty, or
pbcore would crash. This is not desirable. Instead, it should return True when
all Readers are empty, False otherwise.