### PR TITLE
Add support for context constants, statements, and clean up abstractions

### DIFF
--- a/pbcore/io/dataset/EntryPoints.py
+++ b/pbcore/io/dataset/EntryPoints.py
@@ -90,7 +90,7 @@ def filterXml(args):
         raise IOError("No files found/found to be compatible")
 
 def filter_options(parser):
-    pbiFilterOptions = set(Filters()._pbiMappedVecAccMap({}).keys())
+    pbiFilterOptions = set(Filters()._pbiMappedVecAccMap().keys())
     bamFilterOptions = set(Filters()._bamAccMap.keys())
     parser.description = ('Add filters to an XML file. Suggested fields: '
                           '{f}. More expensive fields: {b}'.format(

--- a/tests/test_pbdataset.py
+++ b/tests/test_pbdataset.py
@@ -1004,6 +1004,10 @@ class TestDataSet(unittest.TestCase):
     def test_context_filters(self):
         ss = SubreadSet(upstreamdata.getUnalignedBam())
         self.assertEqual(set(ss.index.contextFlag), {0, 1, 2, 3})
+        self.assertEqual(
+            [len(np.flatnonzero(ss.index.contextFlag == cx))
+             for cx in sorted(set(ss.index.contextFlag))],
+            [15, 33, 32, 37])
         self.assertEqual(len(ss.index), 117)
 
         # no adapters/barcodes
@@ -1024,6 +1028,12 @@ class TestDataSet(unittest.TestCase):
         ss.filters.removeRequirement('cx')
         self.assertEqual(len(ss.index), 117)
 
+        # adapter before
+        ss.filters.addRequirement(cx=[('&', 'ADAPTER_BEFORE')])
+        self.assertEqual(len(ss.index), 70)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
         # adapter after
         ss.filters.addRequirement(cx=[('&', 2)])
         self.assertEqual(len(ss.index), 69)
@@ -1033,6 +1043,20 @@ class TestDataSet(unittest.TestCase):
         # adapter before or after
         ss.filters.addRequirement(cx=[('&', 3)])
         self.assertEqual(len(ss.index), 102)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
+        # adapter before or after
+        ss.filters.addRequirement(cx=[('&', 'ADAPTER_BEFORE | ADAPTER_AFTER')])
+        self.assertEqual(len(ss.index), 102)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
+        # adapter before or after but not both
+        ss.filters.addRequirement(cx=[('!=', 0)])
+        ss.filters.addRequirement(cx=[('~', 1),
+                                      ('~', 2)])
+        self.assertEqual(len(ss.index), 65)
         ss.filters.removeRequirement('cx')
         self.assertEqual(len(ss.index), 117)
 
@@ -1060,6 +1084,19 @@ class TestDataSet(unittest.TestCase):
         # no adapter before
         ss.filters.addRequirement(cx=[('~', 1)])
         self.assertEqual(len(ss.index), 47)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
+        # no adapter before or after
+        ss.filters.addRequirement(cx=[('~', 1)])
+        ss.filters.addRequirement(cx=[('~', 2)])
+        self.assertEqual(len(ss.index), 15)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
+        # no adapter before or after
+        ss.filters.addRequirement(cx=[('~', 3)])
+        self.assertEqual(len(ss.index), 15)
         ss.filters.removeRequirement('cx')
         self.assertEqual(len(ss.index), 117)
 

--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -529,18 +529,18 @@ class TestDataSet(unittest.TestCase):
         self.assertEqual(aln.numRecords, 40)
 
         # AlignmentSet with cmp.h5
-        aln = AlignmentSet(upstreamData.getCmpH5(), strict=True)
-        self.assertEqual(len(aln), 84)
-        self.assertEqual(aln._length, (84, 26103))
-        self.assertEqual(aln.totalLength, 26103)
-        self.assertEqual(aln.numRecords, 84)
+        aln = AlignmentSet(upstreamData.getBamAndCmpH5()[1], strict=True)
+        self.assertEqual(len(aln), 112)
+        self.assertEqual(aln._length, (112, 59970))
+        self.assertEqual(aln.totalLength, 59970)
+        self.assertEqual(aln.numRecords, 112)
         aln.totalLength = -1
         aln.numRecords = -1
         self.assertEqual(aln.totalLength, -1)
         self.assertEqual(aln.numRecords, -1)
         aln.updateCounts()
-        self.assertEqual(aln.totalLength, 26103)
-        self.assertEqual(aln.numRecords, 84)
+        self.assertEqual(aln.totalLength, 59970)
+        self.assertEqual(aln.numRecords, 112)
 
 
         # SubreadSet
@@ -685,8 +685,8 @@ class TestDataSet(unittest.TestCase):
         self.assertEqual(ds[0].name, "lambda_NEB3011")
 
     def test_alignmentset_index(self):
-        aln = AlignmentSet(upstreamData.getCmpH5(), strict=True)
+        aln = AlignmentSet(upstreamData.getBamAndCmpH5()[1], strict=True)
         reads = aln.readsInRange(aln.refNames[0], 0, 1000)
         self.assertEqual(len(list(reads)), 2)
-        self.assertEqual(len(list(aln)), 84)
-        self.assertEqual(len(aln.index), 84)
+        self.assertEqual(len(list(aln)), 112)
+        self.assertEqual(len(aln.index), 112)


### PR DESCRIPTION
The referenceInfoTable, readGroupTable and certain columns of the index table needed some attention in multi-movie and multi-reference situations.