### PR TITLE
Replace bam-centric zmw split

### DIFF
--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -5,6 +5,7 @@ import unittest
 import tempfile
 import os
 import itertools
+import numpy as np
 
 from pbcore.util.Process import backticks
 from pbcore.io.dataset.utils import (consolidateBams, _infixFname,


### PR DESCRIPTION
Reduce the number of assumptions:
- zmws can be split between files
- there can be more than one readgroup per bam

The new code should be a bit simpler and more maintainable. I added tests, but
current tests pass with minor modifications.

Note that the number of chunks produced and their sizes no longer depend on
the number of bam files, which may result in slightly different splits than
before.