### PR TITLE
Add min zmw chunk size, sts loading from extres

### DIFF
--- a/pbcore/io/dataset/DataSetIO.py
+++ b/pbcore/io/dataset/DataSetIO.py
@@ -1933,6 +1933,13 @@ class ReadSet(DataSet):
         active_holenumbers = set(zip(self.index.qId, self.index.holeNumber))
         n_chunks = min(len(active_holenumbers), chunks)
 
+        # if we have a target size and can have two or more chunks:
+        if (not targetSize is None and len(active_holenumbers) > 1 and
+                chunks > 1):
+            n_chunks = min(n_chunks, len(active_holenumbers)/targetSize)
+            # we want at least two if we can swing it:
+            n_chunks = max(n_chunks, 2)
+
         # make sure there aren't too few atoms
         if n_chunks != chunks:
             log.info("Adjusted number of chunks to %d" % n_chunks)

--- a/pbcore/io/dataset/DataSetMembers.py
+++ b/pbcore/io/dataset/DataSetMembers.py
@@ -969,6 +969,14 @@ class ExternalResource(RecordWrapper):
                 return index.resourceId
 
     @property
+    def sts(self):
+        return self._getSubResByMetaType('PacBio.SubreadFile.ChipStatsFile')
+
+    @sts.setter
+    def sts(self, value):
+        self._setSubResByMetaType('PacBio.SubreadFile.ChipStatsFile', value)
+
+    @property
     def scraps(self):
         return self._getSubResByMetaType('PacBio.SubreadFile.ScrapsBamFile')
 

--- a/pbcore/io/dataset/DataSetReader.py
+++ b/pbcore/io/dataset/DataSetReader.py
@@ -58,6 +58,10 @@ def _addXmlFile(dset, path):
     root = tree.getroot()
     tmp = _parseXml(type(dset), root)
     tmp.makePathsAbsolute(curStart=os.path.dirname(path))
+    if not tmp.metadata.summaryStats:
+        for extres in tmp.externalResources:
+            if extres.sts:
+                tmp.loadStats(extres.sts)
     # copyOnMerge must be false, you're merging in a tmp and maintaining dset
     dset.merge(tmp, copyOnMerge=False)
 


### PR DESCRIPTION
Current default is min 5000 zmws per chunk, min 2 chunks if possible (so that
chunking can be tested with small datasets, and 2x fast is still fast).

Load sts.xml files automatically from external resources upon opening.