### PR TITLE
Add a regex to only catch "real" contig windows

### DIFF
--- a/pbcore/io/dataset/DataSetIO.py
+++ b/pbcore/io/dataset/DataSetIO.py
@@ -8,6 +8,7 @@ import datetime
 import math
 import copy
 import os
+import re
 import errno
 import logging
 import itertools
@@ -3635,6 +3636,8 @@ class ContigSet(DataSet):
         """Chunking and quivering appends a window to the contig ID, which
         allows us to consolidate the contig chunks."""
         name, _ = self._popSuffix(name)
+        if re.search("_\d+_\d+$", name) is None:
+            return None
         possibilities = name.split('_')[-2:]
         for pos in possibilities:
             if not pos.isdigit():

--- a/pbcore/io/dataset/DataSetMembers.py
+++ b/pbcore/io/dataset/DataSetMembers.py
@@ -84,6 +84,7 @@ def getTimeStampedName(mType):
     return "{m}-{t}".format(m=mType, t=getTime())
 
 class PbiFlags(object):
+    NO_LOCAL_CONTEXT = 0
     ADAPTER_BEFORE = 1
     ADAPTER_AFTER = 2
     BARCODE_BEFORE = 4

--- a/tests/test_pbdataset.py
+++ b/tests/test_pbdataset.py
@@ -1124,6 +1124,12 @@ class TestDataSet(unittest.TestCase):
         ss.filters.removeRequirement('cx')
         self.assertEqual(len(ss.index), 117)
 
+        # no adapters/barcodes
+        ss.filters.addRequirement(cx=[('=', 'NO_LOCAL_CONTEXT')])
+        self.assertEqual(len(ss.index), 15)
+        ss.filters.removeRequirement('cx')
+        self.assertEqual(len(ss.index), 117)
+
         # some adapters/barcodes
         ss.filters.addRequirement(cx=[('!=', 0)])
         self.assertEqual(len(ss.index), 102)


### PR DESCRIPTION
This still has the potential to hit false positives if the ref_winstart_winend pattern collides with a *_int_int name that someone provides.