### PR TITLE
Missing resources now an error

### DIFF
--- a/pbcore/io/dataset/DataSetIO.py
+++ b/pbcore/io/dataset/DataSetIO.py
@@ -311,7 +311,8 @@ class DataSet(object):
             >>> ds1.numExternalResources
             2
             >>> # Constructors should be used directly
-            >>> SubreadSet(data.getSubreadSet()) # doctest:+ELLIPSIS
+            >>> SubreadSet(data.getSubreadSet(),
+            ...            skipMissing=True) # doctest:+ELLIPSIS
             <SubreadSet...
             >>> # Even with untyped inputs
             >>> AlignmentSet(data.getBam()) # doctest:+ELLIPSIS
@@ -330,6 +331,7 @@ class DataSet(object):
 
         """
         self._strict = kwargs.get('strict', False)
+        skipMissing = kwargs.get('skipMissing', False)
         self._skipCounts = kwargs.get('skipCounts', False)
         _induceIndices = kwargs.get('generateIndices', False)
 
@@ -355,8 +357,7 @@ class DataSet(object):
         populateDataSet(self, files)
         log.debug('Done populating')
 
-        if self._strict:
-            log.debug('Strictly checking ResourceIds')
+        if not skipMissing:
             self._modResources(_fileExists)
 
         # DataSet base class shouldn't really be used. It is ok-ish for just
@@ -940,9 +941,9 @@ class DataSet(object):
             >>> import tempfile, os
             >>> outdir = tempfile.mkdtemp(suffix="dataset-doctest")
             >>> outfile = os.path.join(outdir, 'tempfile.xml')
-            >>> ds1 = DataSet(data.getXml())
+            >>> ds1 = DataSet(data.getXml(), skipMissing=True)
             >>> ds1.write(outfile, validate=False)
-            >>> ds2 = DataSet(outfile)
+            >>> ds2 = DataSet(outfile, skipMissing=True)
             >>> ds1 == ds2
             True
         """
@@ -1167,9 +1168,9 @@ class DataSet(object):
 
         Doctest:
             >>> import pbcore.data.datasets as data
-            >>> from pbcore.io import DataSet
+            >>> from pbcore.io import SubreadSet
             >>> from pbcore.io.dataset.DataSetMembers import Filters
-            >>> ds1 = DataSet()
+            >>> ds1 = SubreadSet()
             >>> filt = Filters()
             >>> filt.addRequirement(rq=[('>', '0.85')])
             >>> ds1.addFilters(filt)
@@ -1472,7 +1473,8 @@ class DataSet(object):
 
         Doctest:
             >>> from pbcore.io import DataSet
-            >>> DataSet("bam1.bam", "bam2.bam", strict=False).toFofn(uri=False)
+            >>> DataSet("bam1.bam", "bam2.bam", strict=False,
+            ...         skipMissing=True).toFofn(uri=False)
             ['bam1.bam', 'bam2.bam']
         """
         lines = [er.resourceId for er in self.externalResources]
@@ -1545,7 +1547,7 @@ class DataSet(object):
     @property
     def filters(self):
         """Limit setting to ensure cache hygiene and filter compatibility"""
-        self._filters.registerCallback(lambda x=self, y=False: x.reFilter(y))
+        self._filters.registerCallback(self._wipeCaches)
         return self._filters
 
     @filters.setter
@@ -1570,6 +1572,9 @@ class DataSet(object):
             if self.metadata.summaryStats:
                 self.metadata.removeChildren('SummaryStats')
             self.updateCounts()
+
+    def _wipeCaches(self):
+        self.reFilter(False)
 
     @property
     def createdAt(self):
@@ -1708,26 +1713,11 @@ class DataSet(object):
 
     def _assertIndexed(self, acceptableTypes):
         if not self._openReaders:
-            try:
-                tmp = self._strict
-                self._strict = True
-                self._openFiles()
-            except Exception:
-                # Catch everything to recover the strictness status, then raise
-                # whatever error was found.
-                self._strict = tmp
-                raise
-            finally:
-                # if the original _strict was not True, these files have been
-                # opened in a strict manner and must be wiped
-                if not tmp:
-                    self.close()
-                self._strict = tmp
-        else:
-            for fname, reader in zip(self.toExternalFiles(),
-                                     self.resourceReaders()):
-                if not isinstance(reader, acceptableTypes):
-                    raise IOError(errno.EIO, "File not indexed", fname)
+            self._openFiles()
+        for fname, reader in zip(self.toExternalFiles(),
+                                 self.resourceReaders()):
+            if not isinstance(reader, acceptableTypes):
+                raise IOError(errno.EIO, "File not indexed", fname)
         return True
 
     def __getitem__(self, index):
@@ -2211,9 +2201,6 @@ class ReadSet(DataSet):
             self.metadata.numRecords = -1
             return
         try:
-            # open the files to take their length (and so they're not reopened
-            # during assertIndexed()):
-            self._openFiles()
             self.assertIndexed()
             log.debug('Updating counts')
             numRecords, totalLength = self._length
@@ -2313,8 +2300,8 @@ class SubreadSet(ReadSet):
         >>> from pbcore.io import SubreadSet
         >>> from pbcore.io.dataset.DataSetMembers import ExternalResources
         >>> import pbcore.data.datasets as data
-        >>> ds1 = SubreadSet(data.getXml(no=5))
-        >>> ds2 = SubreadSet(data.getXml(no=5))
+        >>> ds1 = SubreadSet(data.getXml(no=5), skipMissing=True)
+        >>> ds2 = SubreadSet(data.getXml(no=5), skipMissing=True)
         >>> # So they don't conflict:
         >>> ds2.externalResources = ExternalResources()
         >>> ds1 # doctest:+ELLIPSIS
@@ -2332,7 +2319,7 @@ class SubreadSet(ReadSet):
         >>> ds3 = ds1 + ds2
         >>> len(ds3.metadata.collections)
         2
-        >>> ds4 = SubreadSet(data.getSubreadSet())
+        >>> ds4 = SubreadSet(data.getSubreadSet(), skipMissing=True)
         >>> ds4 # doctest:+ELLIPSIS
         <SubreadSet...
         >>> ds4._metadata # doctest:+ELLIPSIS
@@ -3465,7 +3452,8 @@ class ConsensusReadSet(ReadSet):
     Doctest:
         >>> import pbcore.data.datasets as data
         >>> from pbcore.io import ConsensusReadSet
-        >>> ds2 = ConsensusReadSet(data.getXml(2), strict=False)
+        >>> ds2 = ConsensusReadSet(data.getXml(2), strict=False,
+        ...                        skipMissing=True)
         >>> ds2 # doctest:+ELLIPSIS
         <ConsensusReadSet...
         >>> ds2._metadata # doctest:+ELLIPSIS

--- a/pbcore/io/dataset/DataSetMembers.py
+++ b/pbcore/io/dataset/DataSetMembers.py
@@ -629,6 +629,7 @@ class Filters(RecordWrapper):
         return filterLastResult
 
     def fromString(self, filterString):
+        # TODO(mdsmith)(2016-02-09) finish this
         filtDict = {}
         self._runCallbacks()
 
@@ -661,6 +662,7 @@ class Filters(RecordWrapper):
                 for i, (oper, val) in enumerate(options):
                     newFilts[i].addRequirement(name, oper, val)
             self.extend(newFilts)
+        log.debug("Current filters: {s}".format(s=str(self)))
         self._runCallbacks()
 
     def mapRequirement(self, **kwargs):
@@ -1823,7 +1825,7 @@ class PrimaryMetadata(RecordWrapper):
         >>> import os, tempfile
         >>> from pbcore.io import SubreadSet
         >>> import pbcore.data.datasets as data
-        >>> ds1 = SubreadSet(data.getXml(5))
+        >>> ds1 = SubreadSet(data.getXml(5), skipMissing=True)
         >>> ds1.metadata.collections[0].primary.outputOptions.resultsFolder
         'Analysis_Results'
         >>> ds1.metadata.collections[0].primary.outputOptions.resultsFolder = (
@@ -1833,7 +1835,7 @@ class PrimaryMetadata(RecordWrapper):
         >>> outdir = tempfile.mkdtemp(suffix="dataset-doctest")
         >>> outXml = 'xml:' + os.path.join(outdir, 'tempfile.xml')
         >>> ds1.write(outXml, validate=False)
-        >>> ds2 = SubreadSet(outXml)
+        >>> ds2 = SubreadSet(outXml, skipMissing=True)
         >>> ds2.metadata.collections[0].primary.outputOptions.resultsFolder
         'BetterAnalysis_Results'
     """
@@ -1885,7 +1887,7 @@ class BioSamplesMetadata(RecordWrapper):
         Doctest:
             >>> from pbcore.io import SubreadSet
             >>> import pbcore.data.datasets as data
-            >>> ds = SubreadSet(data.getSubreadSet())
+            >>> ds = SubreadSet(data.getSubreadSet(), skipMissing=True)
             >>> ds.metadata.bioSamples[0].name
             'consectetur purus'
             >>> for bs in ds.metadata.bioSamples:

--- a/pbcore/io/dataset/DataSetMembers.py
+++ b/pbcore/io/dataset/DataSetMembers.py
@@ -575,15 +575,15 @@ class Filters(RecordWrapper):
         if readType == 'bam':
             typeMap = self._bamTypeMap
             accMap = self._pbiVecAccMap()
+            if 'tStart' in indexRecords.dtype.names:
+                accMap = self._pbiMappedVecAccMap()
+                if 'RefGroupID' in indexRecords.dtype.names:
+                    accMap['rname'] = (lambda x: x.RefGroupID)
             if 'MovieID' in indexRecords.dtype.names:
                 # TODO(mdsmith)(2016-01-29) remove these once the fields are
                 # renamed:
                 accMap['movie'] = (lambda x: x.MovieID)
                 accMap['qname'] = (lambda x: x.MovieID)
-            if 'aEnd' in indexRecords.dtype.names:
-                accMap = self._pbiMappedVecAccMap()
-                if 'RefGroupID' in indexRecords.dtype.names:
-                    accMap['rname'] = (lambda x: x.RefGroupID)
         elif readType == 'fasta':
             accMap = {'id': (lambda x: x.id),
                       'length': (lambda x: int(x.length)),

--- a/pbcore/io/dataset/DataSetReader.py
+++ b/pbcore/io/dataset/DataSetReader.py
@@ -126,12 +126,6 @@ def wrapNewResource(path):
 def _parseXml(dsetType, element):
     """Parse an XML DataSet tag, or the root tag of a DataSet XML file (they
     should be equivalent)
-
-    Doctest:
-        >>> import pbcore.data.datasets as data
-        >>> ds = _openXmlFile(data.getXml(no=8).split(':')[-1])
-        >>> type(ds).__name__
-        'SubreadSet'
     """
     result = dsetType()
     result.objMetadata = element.attrib
@@ -237,15 +231,6 @@ def _parseXmlFilters(element):
     """Pull filters from XML file, put them in a list of dictionaries, where
     each dictionary contains a representation of a Filter tag: key, value pairs
     with parameter names and value expressions.
-
-    Doctest:
-        >>> import xml.etree.ElementTree as ET
-        >>> import pbcore.data.datasets as data
-        >>> tree = ET.parse(data.getXml(no=8).split(':')[1])
-        >>> root = tree.getroot()
-        >>> filters = root[1]
-        >>> str(_parseXmlFilters(filters))
-        '( rq > 0.75 ) OR ( qname == 100/0/0_100 )'
     """
     return Filters(_eleToDictList(element))
 

--- a/tests/test_pbdataset.py
+++ b/tests/test_pbdataset.py
@@ -1431,6 +1431,76 @@ class TestDataSet(unittest.TestCase):
         self.assertEqual(ds.refWindows, [('E.faecalis.2', 0, 99),
                                          ('E.faecalis.2', 100, 299)])
 
+    def test_intervalContour(self):
+        ds = AlignmentSet(data.getBam(0))
+        coverage = ds.intervalContour('E.faecalis.1')
+        ds.filters.addRequirement(rname=[('=', 'E.faecalis.1')])
+        # regular totalLength uses aEnd/aStart, which includes insertions
+        totalTargetLength = sum(ds.index.tEnd - ds.index.tStart)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
+        # partial interval
+        ds = AlignmentSet(data.getBam(0))
+        coverage = ds.intervalContour('E.faecalis.1', tStart=100, tEnd=500)
+        ds.filters.addRequirement(rname=[('=', 'E.faecalis.1')],
+                                  tStart=[('<', '500')],
+                                  tEnd=[('>', '100')])
+        # regular totalLength uses aEnd/aStart, which includes insertions
+        ends = ds.index.tEnd
+        post = ends > 500
+        ends[post] = 500
+        starts = ds.index.tStart
+        pre = starts < 100
+        starts[pre] = 100
+        totalTargetLength = sum(ends - starts)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
+        # test a second reference in this set
+        ds.filters.removeRequirement('rname')
+        coverage = ds.intervalContour('E.faecalis.2')
+        ds.filters.addRequirement(rname=[('=', 'E.faecalis.2')])
+        totalTargetLength = sum(ds.index.tEnd - ds.index.tStart)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
+        # partial interval
+        ds = AlignmentSet(data.getBam(0))
+        coverage = ds.intervalContour('E.faecalis.2', tStart=100, tEnd=500)
+        ds.filters.addRequirement(rname=[('=', 'E.faecalis.2')],
+                                  tStart=[('<', '500')],
+                                  tEnd=[('>', '100')])
+        # regular totalLength uses aEnd/aStart, which includes insertions
+        ends = ds.index.tEnd
+        post = ends > 500
+        ends[post] = 500
+        starts = ds.index.tStart
+        pre = starts < 100
+        starts[pre] = 100
+        totalTargetLength = sum(ends - starts)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
+
+        # test a cmp.h5 alignmentset
+        ds = AlignmentSet(upstreamdata.getBamAndCmpH5()[1])
+        coverage = ds.intervalContour('lambda_NEB3011')
+        totalTargetLength = sum(ds.index.tEnd - ds.index.tStart)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
+        # partial interval
+        ds = AlignmentSet(upstreamdata.getBamAndCmpH5()[1])
+        coverage = ds.intervalContour('lambda_NEB3011', tStart=100, tEnd=500)
+        ds.filters.addRequirement(rname=[('=', 'lambda_NEB3011')],
+                                  tStart=[('<', '500')],
+                                  tEnd=[('>', '100')])
+        # regular totalLength uses aEnd/aStart, which includes insertions
+        starts = ds.index.tStart
+        ends = ds.index.tEnd
+        post = ends > 500
+        ends[post] = 500
+        pre = starts < 100
+        starts[pre] = 100
+        totalTargetLength = sum(ends - starts)
+        self.assertEqual(totalTargetLength, sum(coverage))
+
 
     def test_refLengths(self):
         ds = AlignmentSet(data.getBam(0))

--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -525,6 +525,8 @@ class TestDataSet(unittest.TestCase):
         aln.updateCounts()
         self.assertEqual(aln.totalLength, 123588)
         self.assertEqual(aln.numRecords, 92)
+        self.assertEqual(sum(1 for _ in aln), 92)
+        self.assertEqual(sum(len(rec) for rec in aln), 123588)
 
         # AlignmentSet with filters
         aln = AlignmentSet(data.getXml(15), strict=True)
@@ -568,6 +570,8 @@ class TestDataSet(unittest.TestCase):
         sset.updateCounts()
         self.assertEqual(sset.totalLength, 124093)
         self.assertEqual(sset.numRecords, 92)
+        self.assertEqual(sum(1 for _ in sset), 92)
+        self.assertEqual(sum(len(rec) for rec in sset), 124093)
 
         # HdfSubreadSet
         # len means something else in bax/bas land. These numbers may actually

--- a/tests/test_pbdataset_subtypes.py
+++ b/tests/test_pbdataset_subtypes.py
@@ -49,8 +49,8 @@ class TestDataSet(unittest.TestCase):
 
 
     def test_subread_build(self):
-        ds1 = SubreadSet(data.getXml(no=5))
-        ds2 = SubreadSet(data.getXml(no=5))
+        ds1 = SubreadSet(data.getXml(no=5), skipMissing=True)
+        ds2 = SubreadSet(data.getXml(no=5), skipMissing=True)
         self.assertEquals(type(ds1).__name__, 'SubreadSet')
         self.assertEquals(ds1._metadata.__class__.__name__,
                           'SubreadSetMetadata')
@@ -60,7 +60,7 @@ class TestDataSet(unittest.TestCase):
         self.assertEquals(len(ds2.metadata.collections), 1)
         ds3 = ds1 + ds2
         self.assertEquals(len(ds3.metadata.collections), 2)
-        ds4 = SubreadSet(data.getSubreadSet())
+        ds4 = SubreadSet(data.getSubreadSet(), skipMissing=True)
         self.assertEquals(type(ds4).__name__, 'SubreadSet')
         self.assertEquals(type(ds4._metadata).__name__, 'SubreadSetMetadata')
         self.assertEquals(len(ds4.metadata.collections), 1)
@@ -133,10 +133,10 @@ class TestDataSet(unittest.TestCase):
             self.assertTrue(ds[name].id == name)
 
     def test_ccsread_build(self):
-        ds1 = ConsensusReadSet(data.getXml(2), strict=False)
+        ds1 = ConsensusReadSet(data.getXml(2), strict=False, skipMissing=True)
         self.assertEquals(type(ds1).__name__, 'ConsensusReadSet')
         self.assertEquals(type(ds1._metadata).__name__, 'SubreadSetMetadata')
-        ds2 = ConsensusReadSet(data.getXml(2), strict=False)
+        ds2 = ConsensusReadSet(data.getXml(2), strict=False, skipMissing=True)
         self.assertEquals(type(ds2).__name__, 'ConsensusReadSet')
         self.assertEquals(type(ds2._metadata).__name__, 'SubreadSetMetadata')
 
@@ -157,7 +157,8 @@ class TestDataSet(unittest.TestCase):
         ds1.write(fn)
 
     def test_ccsalignment_build(self):
-        ds1 = ConsensusAlignmentSet(data.getXml(20), strict=False)
+        ds1 = ConsensusAlignmentSet(data.getXml(20), strict=False,
+                                    skipMissing=True)
         self.assertEquals(type(ds1).__name__, 'ConsensusAlignmentSet')
         self.assertEquals(type(ds1._metadata).__name__, 'SubreadSetMetadata')
         # XXX strict=True requires actual existing .bam files
@@ -219,10 +220,10 @@ class TestDataSet(unittest.TestCase):
 
 
     def test_contigset_build(self):
-        ds1 = ContigSet(data.getXml(3))
+        ds1 = ContigSet(data.getXml(3), skipMissing=True)
         self.assertEquals(type(ds1).__name__, 'ContigSet')
         self.assertEquals(type(ds1._metadata).__name__, 'ContigSetMetadata')
-        ds2 = ContigSet(data.getXml(3))
+        ds2 = ContigSet(data.getXml(3), skipMissing=True)
         self.assertEquals(type(ds2).__name__, 'ContigSet')
         self.assertEquals(type(ds2._metadata).__name__, 'ContigSetMetadata')
         for contigmd in ds2.metadata.contigs:
@@ -633,7 +634,7 @@ class TestDataSet(unittest.TestCase):
 
     def test_nested_external_resources(self):
         log.debug("Testing nested externalResources in AlignmentSets")
-        aln = AlignmentSet(data.getXml(0))
+        aln = AlignmentSet(data.getXml(0), skipMissing=True)
         self.assertTrue(aln.externalResources[0].pbi)
         self.assertTrue(aln.externalResources[0].reference)
         self.assertEqual(
@@ -642,7 +643,7 @@ class TestDataSet(unittest.TestCase):
         self.assertEqual(aln.externalResources[0].scraps, None)
 
         log.debug("Testing nested externalResources in SubreadSets")
-        subs = SubreadSet(data.getXml(5))
+        subs = SubreadSet(data.getXml(5), skipMissing=True)
         self.assertTrue(subs.externalResources[0].scraps)
         self.assertEqual(
             subs.externalResources[0].externalResources[0].metaType,


### PR DESCRIPTION
If an external resource file is missing an exception will now be raised by default. You can override this by giving the constructor skipMissing=True. This may cause some breakage initially, but is probably the correct behavior.

Also, improved intervalContour and other functions.