### PR TITLE
read entire sequence at once when writing IndexedFastaRecord

### DIFF
--- a/pbcore/io/FastaIO.py
+++ b/pbcore/io/FastaIO.py
@@ -253,7 +253,7 @@ class FastaWriter(WriterBase):
         if len(args) == 1:
             record = args[0]
             if isinstance(record, IndexedFastaRecord):
-                record = FastaRecord(record.header, record.sequence)
+                record = FastaRecord(record.header, record.sequence[:])
             assert isinstance(record, FastaRecord)
         else:
             header, sequence = args


### PR DESCRIPTION
The repeated calls to `__getitem__()` were resulting in an unexpectedly large bottleneck; converting it to a string first fixes the problem.