### PR TITLE
Fix compatibility with pysam 0.9.0

### DIFF
--- a/pbcore/io/dataset/utils.py
+++ b/pbcore/io/dataset/utils.py
@@ -127,11 +127,11 @@ def _sortBam(fname):
     shutil.move(tmpname, fname)
 
 def _indexBam(fname):
-    pysam.index(fname)
+    pysam.samtools.index(fname, catch_stdout=False)
     return fname + ".bai"
 
 def _indexFasta(fname):
-    pysam.faidx(fname)
+    pysam.samtools.faidx(fname, catch_stdout=False)
     return fname + ".fai"
 
 def _mergeBams(inFiles, outFile):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cython
 numpy >= 1.7.1
 h5py >= 2.0.1
-pysam == 0.8.4
+pysam >= 0.9.0


### PR DESCRIPTION
Both pysam.{index,faidx} and pysam.samtools.{index,faidx} will work,
but the latter is the newly preferred way.

catch_stdout apparently has to be disabled to fix the build issue.