### PR TITLE
Update URL to download hdf5 1.8.12 in CI

### DIFF
--- a/.circleci/installHDF5.sh
+++ b/.circleci/installHDF5.sh
@@ -1,7 +1,7 @@
 set -x
 set -e
 if [ ! -e prefix/lib/libhdf5.so ]; then
-  wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz
+  wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz
   tar xzf hdf5-1.8.12.tar.gz
   mkdir -p prefix
   PREFIX=$PWD/prefix


### PR DESCRIPTION
(Spotted while trying to debug failing tests of pbcore with Python 3.7 and numpy 1.16)