### PR TITLE
chore(python 3.12): remove pkg_resources usage

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,12 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import pkg_resources
 import sys, os
 
+from importlib.metadata import Distribution, PackageNotFoundError
+
 try:
-    __VERSION__ = pkg_resources.get_distribution('pbcore').version
-except Exception:
+    __VERSION__ = Distribution.from_name('pbcore').version
+except PackageNotFoundError:
     __VERSION__ = 'unknown'
 
 

--- a/pbcore/__init__.py
+++ b/pbcore/__init__.py
@@ -1,6 +1,6 @@
-import pkg_resources
+from importlib.metadata import Distribution, PackageNotFoundError
 
 try:
-    __VERSION__ = pkg_resources.get_distribution('pbcore').version
-except Exception:
+    __VERSION__ = Distribution.from_name('pbcore').version
+except PackageNotFoundError:
     __VERSION__ = 'unknown'

--- a/pbcore/chemistry/chemistry.py
+++ b/pbcore/chemistry/chemistry.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import xml.etree.ElementTree as ET
 import os.path
 
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 
 
 class ChemistryLookupError(Exception):
@@ -34,18 +34,20 @@ def _loadBarcodeMappingsFromFile(mapFile):
 
 
 def _loadBarcodeMappings():
-    mappingFname = resource_filename(Requirement.parse(
-        'pbcore'), 'pbcore/chemistry/resources/mapping.xml')
-    mappings = _loadBarcodeMappingsFromFile(mappingFname)
-    updMappingDir = os.getenv("SMRT_CHEMISTRY_BUNDLE_DIR")
-    if updMappingDir:
-        import logging
-        from os.path import join
-        logging.info(
-            "Loading updated chemistry mapping XML from {}".format(updMappingDir))
-        mappings.update(_loadBarcodeMappingsFromFile(
-            join(updMappingDir, 'chemistry.xml')))
-    return mappings
+    mappingFnameContext = resources.as_file(
+            resources.files('pbcore') /
+                'chemistry/resources/mapping.xml')
+    with mappingFnameContext as mappingFname:
+        mappings = _loadBarcodeMappingsFromFile(mappingFname)
+        updMappingDir = os.getenv("SMRT_CHEMISTRY_BUNDLE_DIR")
+        if updMappingDir:
+            import logging
+            from os.path import join
+            logging.info(
+                "Loading updated chemistry mapping XML from {}".format(updMappingDir))
+            mappings.update(_loadBarcodeMappingsFromFile(
+                join(updMappingDir, 'chemistry.xml')))
+        return mappings
 
 
 _BARCODE_MAPPINGS = _loadBarcodeMappings()

--- a/pbcore/data/__init__.py
+++ b/pbcore/data/__init__.py
@@ -1,4 +1,4 @@
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 
 MOVIE_NAME_14 = "m110818_075520_42141_c100129202555500000315043109121112_s1_p0"
 MOVIE_NAME_20 = "m130522_092457_42208_c100497142550000001823078008081323_s1_p0"
@@ -9,7 +9,10 @@ MOVIE_NAME_BC = "m140307_221913_42203_c100626172550000001823119008061414_s1_p0"
 
 
 def _getAbsPath(fname):
-    return resource_filename(Requirement.parse('pbcore'), 'pbcore/data/%s' % fname)
+    with resources.as_file(
+       resources.files('pbcore') /
+            'data' / fname) as ret:
+        return str(ret)
 
 
 def getCCSBAM():

--- a/pbcore/data/datasets/__init__.py
+++ b/pbcore/data/datasets/__init__.py
@@ -1,7 +1,7 @@
 """Doctest resources"""
 
 import os
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 
 XML_FILES = ["alignment.dataset.xml",  # 0
              "barcode.dataset.xml",
@@ -33,8 +33,10 @@ FOFN_FILES = ["fofn.fofn"]
 
 
 def _getAbsPath(fname):
-    return resource_filename(Requirement.parse('pbcore'),
-                             'pbcore/data/datasets/%s' % fname)
+    with resources.as_file(
+        resources.files('pbcore') /
+            'data/datasets' / fname) as ret:
+        return str(ret)
 
 
 def getXml(no=0):


### PR DESCRIPTION
Python 3.12 no longer installs setuptools. This means that  pkg_resources is no longer available by default[1].

The existing pkg_resources calls can be migrated to importlib.

[1] https://github.com/python/cpython/issues/95299