### PR TITLE
Workaround overflow errors with Numpy ≥ 2.

### DIFF
--- a/pbcore/io/align/BamAlignment.py
+++ b/pbcore/io/align/BamAlignment.py
@@ -595,7 +595,11 @@ class BamAlignment(AlignmentRecordMixin):
         if data.dtype == np.int8:
             gapCode = ord("-")
         else:
-            gapCode = data.dtype.type(-1)
+            try:
+                gapCode = data.dtype.type(-1)
+            except OverflowError:
+                # FIXME: workaround unsigned types overflow with numpy 2+.
+                gapCode = data.dtype.type(np.iinfo(data.dtype).max)
         uc = self.unrolledCigar(orientation=orientation)
         alnData = np.repeat(np.array(gapCode, dtype=data.dtype), len(uc))
         gapMask = (uc == gapOp)

--- a/pbcore/io/align/_BamSupport.py
+++ b/pbcore/io/align/_BamSupport.py
@@ -68,8 +68,13 @@ BAM_CDIFF = 8
 # qId calculation from RG ID string
 #
 def rgAsInt(rgIdString):
-    return np.int32(int(re.sub("-", "", rgIdString.split("/")[0]), 16)
-                    % (np.iinfo(np.int32).max+1))
+    numericId = int(re.sub("-", "", rgIdString.split("/")[0]), 16)
+    # Identifiers may exceed the 32-bit range, so compensate manually
+    # the overflow, otherwise numpy 2 and later raises OverflowError.
+    overflownId = (numericId + np.iinfo(np.int32).min) \
+                  % (2 * (np.iinfo(np.int32).max + 1)) \
+                  + np.iinfo(np.int32).min
+    return np.int32(overflownId)
 
 #
 # Kinetics: decode the scheme we are using to encode approximate frame

--- a/pbcore/io/align/_BamSupport.py
+++ b/pbcore/io/align/_BamSupport.py
@@ -1,6 +1,7 @@
 # Author: David Alexander
 
 import numpy as np
+import re
 
 
 class UnavailableFeature(Exception):
@@ -67,7 +68,8 @@ BAM_CDIFF = 8
 # qId calculation from RG ID string
 #
 def rgAsInt(rgIdString):
-    return np.int32(int(rgIdString.split("/")[0], 16))
+    return np.int32(int(re.sub("-", "", rgIdString.split("/")[0]), 16)
+                    % (np.iinfo(np.int32).max+1))
 
 #
 # Kinetics: decode the scheme we are using to encode approximate frame


### PR DESCRIPTION
This change works around OverflowError regressions caught by the test suite with Numpy 2 and later, independently reported in [issue #127] and in [Debian bug #1095090], by restoring the former (potentially buggy) behavior with uncaught overflows.  Issues manifested like:

	  File "/home/shuaiw/miniconda3/envs/methy/lib/python3.12/site-packages/pbcore/io/align/_BamSupport.py", line 66, in rgAsInt
	    return np.int32(int(rgIdString.split("/")[0], 16))
	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	OverflowError: Python integer 3367457666 out of bounds for int32

and like:

	    def _gapify(self, data, orientation, gapOp):
	        if self.isUnmapped:
	            return data

	        # Precondition: data must already be *in* the specified orientation
	        if data.dtype == np.int8:
	            gapCode = ord("-")
	        else:
	>           gapCode = data.dtype.type(-1)
	E           OverflowError: Python integer -1 out of bounds for uint8

While being at it, the change includes a fix proposal for situations where identifiers include hyphenations, fixing:

	    return np.int32(int(rgIdString.split("/")[0], 16))
	                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	ValueError: invalid literal for int() with base 16: 'cb4d472d-100C60F6'

[issue #127]: https://github.com/PacificBiosciences/pbcore/issues/127
[Debian bug #1095090]: https://bugs.debian.org/1095090